### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/website/components.d.ts
+++ b/website/components.d.ts
@@ -5,7 +5,7 @@ import '@vue/runtime-core'
 
 export {}
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     Aside: typeof import('./src/components/Aside.vue')['default']
     AsideCategory: typeof import('./src/components/AsideCategory.vue')['default']


### PR DESCRIPTION

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.